### PR TITLE
Generate random PostgreSQL credentials at first startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,7 @@ ENV NODE_ENV=production
 
 RUN npm ci
 
-ENV POSTGRES_PASSWORD=adminpw
 ENV APP_USERNAME=repl
-ENV APP_PASSWORD=replpw
 ENV APP_DATABASE=replicator
 
 RUN apk add --update nodejs npm

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,29 @@
 #!/bin/bash
-cd /replicator
-npm start & /usr/local/bin/docker-entrypoint.sh postgres
+set -e
+
+if [ -z "$JINAGA_POSTGRESQL" ]; then
+  # Internal PostgreSQL mode: generate and persist credentials
+  CREDS_FILE="$PGDATA/.replicator-creds"
+
+  if [ ! -f "$CREDS_FILE" ]; then
+    mkdir -p "$PGDATA"
+    printf "POSTGRES_PASSWORD=%s\nAPP_PASSWORD=%s\n" \
+      "$(od -An -tx1 -N32 /dev/urandom | tr -d ' \n')" \
+      "$(od -An -tx1 -N32 /dev/urandom | tr -d ' \n')" \
+      > "$CREDS_FILE"
+    chmod 600 "$CREDS_FILE"
+  fi
+
+  # shellcheck source=/dev/null
+  . "$CREDS_FILE"
+  export POSTGRES_PASSWORD APP_PASSWORD
+
+  export JINAGA_POSTGRESQL="postgresql://${APP_USERNAME}:${APP_PASSWORD}@localhost:5432/${APP_DATABASE}"
+
+  cd /replicator
+  npm start & exec /usr/local/bin/docker-entrypoint.sh postgres
+else
+  # External PostgreSQL mode: skip internal postgres entirely
+  cd /replicator
+  exec npm start
+fi


### PR DESCRIPTION
## Summary

- Removes hardcoded `POSTGRES_PASSWORD` and `APP_PASSWORD` defaults from the Dockerfile, eliminating the `SecretsUsedInArgOrEnv` build warning
- `start.sh` generates random 32-byte hex credentials on first container start and persists them to `$PGDATA/.replicator-creds` (chmod 600)
- `JINAGA_POSTGRESQL` is derived automatically from the generated credentials — no configuration burden on consumers
- If `JINAGA_POSTGRESQL` is provided externally, internal PostgreSQL is skipped entirely (external DB mode)

## Migration

Consumers upgrading from an older image who have an existing PostgreSQL data volume should create `$PGDATA/.replicator-creds` before starting the new container:

```
POSTGRES_PASSWORD=adminpw
APP_PASSWORD=replpw
```

This is a one-time step. The values are the well-known defaults that were previously baked into the image.

## Test plan

- [ ] Fresh start: verify container starts, postgres initializes, replicator connects
- [ ] Restart: verify credentials file is read and container reconnects without re-initializing postgres
- [ ] External DB: verify that setting `JINAGA_POSTGRESQL` skips internal postgres startup
- [ ] Confirm `SecretsUsedInArgOrEnv` warning is gone from build annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)