### PR TITLE
Upgrade jinaga to ^6.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/sdk-trace-node": "^1.30.1",
         "chardet": "^2.0.0",
         "express": "^4.21.2",
-        "jinaga": "^6.8.0",
+        "jinaga": "^6.8.2",
         "jinaga-server": "^3.6.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.13.1"
@@ -2946,9 +2946,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.8.0.tgz",
-      "integrity": "sha512-YN2CtA3PcIDpLR/2fQQTSX5IeoxynEVXLtvHWfK2bUpDrPzfDjsxc8ALbN7OZlEVMeOZuxvtQdgHYH79qqe0iQ==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.8.2.tgz",
+      "integrity": "sha512-Rp9dRJA0DQL2iIJeLyLxzqTSe0isalShs/cxYH2WWbHZ17OpqzEgJ1RwlAEEFOgw6LGAcwW3OyeE/JsxuKQ4qQ==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@opentelemetry/sdk-trace-node": "^1.30.1",
     "chardet": "^2.0.0",
     "express": "^4.21.2",
-    "jinaga": "^6.8.0",
+    "jinaga": "^6.8.2",
     "jinaga-server": "^3.6.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.13.1"


### PR DESCRIPTION
## Summary

Upgrades the `jinaga` dependency `^6.8.0` → `^6.8.2` so the published Docker image picks up the distribution authorization fix from [jinaga#205](https://github.com/jinaga/jinaga.js/pull/205) (shipped in `jinaga@6.8.2`).

Unlike a client app — which gets the fix simply by upgrading its own `jinaga` — the replicator **bundles** jinaga into its Docker image, so it needs this dependency upgrade to deliver the fix to deployed replicators.

## The fix

A direct query for an **intermediate** fact that a `.select()` projection rule only traverses through (e.g. `Finalist`, used only to reach the `competitor` it projects) is now authorized, instead of being rejected with `Cannot distribute … No rules apply to this feed`. The relaxation is sound — it only admits sub-feeds whose every output fact the rule already delivers. Server-side coverage was added in jinaga-server [#165](https://github.com/jinaga/jinaga-server/pull/165).

## Verification

- `jinaga` resolves to a single hoisted `6.8.2`, shared with `jinaga-server@3.6.0` (no stale nested copy).
- `npm run build` (`tsc`) is clean.
- Lockfile change is solely the `jinaga` 6.8.0 → 6.8.2 resolution.

## Releasing the Docker image

After merge, follow the documented release process (README → Release): on `main`, `npm version patch` + `git push --follow-tags`, which triggers the GitHub Actions workflow to build and publish the new Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)