### PR TITLE
Support JWKS-endpoint key resolution for .provider authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The Jinaga Replicator is a **fact storage and distribution node** in a Jinaga me
 
 ### Key modules
 
-- **`authenticate.ts`** — Builds a JWT authentication function for `JinagaServer`. Reads `.authentication` files (one per provider); each file contains a public key (RSA/symmetric) plus optional `iss`/`aud` constraints. Supports anonymous access if `allow-anonymous` marker file is present.
+- **`authenticate.ts`** — Builds a JWT authentication function for `JinagaServer`. Reads `.provider` files (one per provider); each file matches on `iss`/`aud` and resolves the signing key either from a static `key`/`key_id` (RSA PEM or symmetric secret) or dynamically from a `jwks_uri` endpoint by the token's `kid` (with caching and cache-miss refetch via `jwks-rsa`, supporting RS256 key rotation). Verification is async (awaited) and constrained by an explicit algorithm allowlist (RS256 for asymmetric/JWKS keys, HMAC family for symmetric keys). Supports anonymous access if `allow-anonymous` marker file is present.
 
 - **`loadPolicies.ts`** — Reads `.policy` files containing Jinaga authorization, distribution, and purge rules. Merges them into a single `RuleSet` for `JinagaServer`. Security is bypassed entirely if `no-security-policies` marker file is present.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Replace `/path/to/your/authentication` with the path to the directory on your ho
 
 ### JSON Provider File Specification
 
-Each JSON provider file should have the following structure:
+A provider can resolve signing keys in one of two mutually exclusive ways:
+
+1. **Static key** — pin a single key with `key_id` and `key`. Best for offline or symmetric (shared-secret) setups.
+2. **JWKS endpoint** — declare a `jwks_uri` and the replicator resolves the signing key dynamically by the token's `kid` against the issuer's JWKS document (e.g. `.well-known/jwks.json`). Keys are cached and re-fetched on a cache miss, so issuer key rotation (including KMS-backed rotation) is picked up automatically without regenerating the file.
+
+A provider file must use exactly one of these modes. Specifying `jwks_uri` together with `key` or `key_id` is rejected at startup.
 
 ```json
 {
@@ -58,19 +63,23 @@ Each JSON provider file should have the following structure:
     "issuer": "string",
     "audience": "string",
     "key_id": "string",
-    "key": "string"
+    "key": "string",
+    "jwks_uri": "string"
 }
 ```
 
 - `provider`: A unique identifier for the authentication provider.
 - `issuer`: The expected issuer (`iss`) claim in the JWT.
 - `audience`: The expected audience (`aud`) claim in the JWT.
-- `key_id`: The key identifier (`kid`) used to select the key for verifying the JWT signature.
-- `key`: The key used to verify the JWT signature. This can be a PEM-encoded public key for asymmetric algorithms, or a shared key for symmetric algorithms.
+- `key_id` *(static mode)*: The key identifier (`kid`) used to select the key for verifying the JWT signature.
+- `key` *(static mode)*: The key used to verify the JWT signature. This can be a PEM-encoded public key for asymmetric algorithms, or a shared key for symmetric algorithms.
+- `jwks_uri` *(JWKS mode)*: The HTTP(S) URL of the issuer's JWKS document. The signing key is selected by the token's `kid`.
 
-### Example
+The replicator enforces an explicit algorithm allowlist when verifying signatures (defense-in-depth against algorithm-confusion attacks): PEM public keys and JWKS-resolved keys are restricted to `RS256`, while static symmetric keys permit the HMAC family (`HS256`, `HS384`, `HS512`).
 
-Here is an example of an authentication provider file using RSA validation:
+### Examples
+
+An authentication provider using a static RSA public key:
 
 ```json
 {
@@ -79,6 +88,17 @@ Here is an example of an authentication provider file using RSA validation:
     "audience": "my-replicator",
     "key_id": "WVoKvLhSUl8cJRNGo6pKUUvia8Q",
 	"key": "-----BEGIN PUBLIC KEY-----\nMIIBI...DAQAB\n-----END PUBLIC KEY-----"
+}
+```
+
+An authentication provider that resolves keys from a JWKS endpoint (supports RS256 key rotation):
+
+```json
+{
+    "provider": "example-jwks",
+    "issuer": "https://example.com",
+    "audience": "my-replicator",
+    "jwks_uri": "https://example.com/.well-known/jwks.json"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,25 @@ A provider can resolve signing keys in one of two mutually exclusive ways:
 
 A provider file must use exactly one of these modes. Specifying `jwks_uri` together with `key` or `key_id` is rejected at startup.
 
+A **static key** provider has this shape:
+
 ```json
 {
     "provider": "string",
     "issuer": "string",
     "audience": "string",
     "key_id": "string",
-    "key": "string",
+    "key": "string"
+}
+```
+
+A **JWKS endpoint** provider has this shape:
+
+```json
+{
+    "provider": "string",
+    "issuer": "string",
+    "audience": "string",
     "jwks_uri": "string"
 }
 ```

--- a/authenticate.ts
+++ b/authenticate.ts
@@ -3,19 +3,29 @@ import { NextFunction, Request, Response } from "express";
 import { readdir, readFile } from "fs/promises";
 import * as iconv from "iconv-lite";
 import { Trace } from "jinaga";
-import { decode, JwtPayload, verify } from "jsonwebtoken";
+import { Algorithm, decode, GetPublicKeyOrSecret, JwtHeader, JwtPayload, SigningKeyCallback, verify } from "jsonwebtoken";
+import jwksRsa = require("jwks-rsa");
 import { join } from "path";
 
 interface AuthenticationConfiguration {
     provider: string;
     issuer: string;
     audience: string;
-    keyId: string;
-    key: string;
+    keyId?: string;
+    key?: string;
+    jwksUri?: string;
+    jwksClient?: jwksRsa.JwksClient;
+}
+
+const RSA_ALGORITHMS: Algorithm[] = ["RS256"];
+const HMAC_ALGORITHMS: Algorithm[] = ["HS256", "HS384", "HS512"];
+
+function isPemKey(key: string): boolean {
+    return key.includes("-----BEGIN");
 }
 
 export function authenticate(configs: AuthenticationConfiguration[], allowAnonymous: boolean) {
-    return (req: Request, res: Response, next: NextFunction) => {
+    return async (req: Request, res: Response, next: NextFunction) => {
         let possibleConfigs: AuthenticationConfiguration[] = configs;
 
         try {
@@ -65,22 +75,13 @@ export function authenticate(configs: AuthenticationConfiguration[], allowAnonym
 
                     let verified: string | JwtPayload | undefined;
                     let provider: string = "";
-                    verify(token, (header, callback) => {
-                        const config = possibleConfigs.find(config => config.keyId === header.kid);
-                        if (!config) {
-                            callback(new Error(`Invalid key ID: ${header.kid}`));
-                            return;
-                        }
-                        provider = config.provider;
-                        callback(null, config.key);
-                    }, (error, payload) => {
-                        if (!error) {
-                            verified = payload;
-                        }
-                        else {
-                            Trace.warn(`Error during authentication: ${error.message || error}`);
-                        }
-                    });
+                    try {
+                        const result = await verifyToken(token, possibleConfigs);
+                        verified = result.payload;
+                        provider = result.provider;
+                    } catch (error) {
+                        Trace.warn(`Error during authentication: ${error instanceof Error ? error.message : error}`);
+                    }
 
                     if (!verified) {
                         res.set('Access-Control-Allow-Origin', '*');
@@ -112,6 +113,68 @@ export function authenticate(configs: AuthenticationConfiguration[], allowAnonym
             next(error);
         }
     }
+}
+
+// Resolve the signing key for a token by its `kid`, supporting both static keys
+// (matched by `key_id`) and dynamic JWKS endpoints (resolved by `kid`, with
+// caching and cache-miss refetch handled by jwks-rsa). The verification is
+// asynchronous because JWKS resolution may require a network round-trip.
+function verifyToken(
+    token: string,
+    possibleConfigs: AuthenticationConfiguration[]
+): Promise<{ payload: string | JwtPayload; provider: string }> {
+    return new Promise((resolve, reject) => {
+        let provider: string = "";
+
+        const getKey: GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => {
+            // Prefer a static key whose key_id matches the token's kid.
+            const staticConfig = possibleConfigs.find(config => config.key !== undefined && config.keyId === header.kid);
+            if (staticConfig) {
+                provider = staticConfig.provider;
+                callback(null, staticConfig.key);
+                return;
+            }
+
+            // Fall back to a JWKS endpoint, resolving the key by kid.
+            const jwksConfig = possibleConfigs.find(config => config.jwksClient !== undefined);
+            if (jwksConfig && jwksConfig.jwksClient) {
+                provider = jwksConfig.provider;
+                jwksConfig.jwksClient.getSigningKey(header.kid, (error, key) => {
+                    if (error || !key) {
+                        callback(error ?? new Error(`Invalid key ID: ${header.kid}`));
+                        return;
+                    }
+                    callback(null, key.getPublicKey());
+                });
+                return;
+            }
+
+            callback(new Error(`Invalid key ID: ${header.kid}`));
+        };
+
+        verify(token, getKey, { algorithms: allowedAlgorithms(possibleConfigs) }, (error, payload) => {
+            if (error || !payload) {
+                reject(error ?? new Error("Token verification produced no payload"));
+                return;
+            }
+            resolve({ payload, provider });
+        });
+    });
+}
+
+// Compute the explicit algorithms allowlist (defense-in-depth against
+// algorithm-confusion attacks such as RS256 -> HS256). Asymmetric keys (PEM or
+// JWKS) permit RS256; static symmetric secrets permit the HMAC family.
+function allowedAlgorithms(possibleConfigs: AuthenticationConfiguration[]): Algorithm[] {
+    const algorithms = new Set<Algorithm>();
+    for (const config of possibleConfigs) {
+        if (config.jwksUri !== undefined || (config.key !== undefined && isPemKey(config.key))) {
+            RSA_ALGORITHMS.forEach(algorithm => algorithms.add(algorithm));
+        } else if (config.key !== undefined) {
+            HMAC_ALGORITHMS.forEach(algorithm => algorithms.add(algorithm));
+        }
+    }
+    return [...algorithms];
 }
 
 export async function loadAuthenticationConfigurations(path: string): Promise<{ configs: AuthenticationConfiguration[], allowAnonymous: boolean }> {
@@ -171,11 +234,46 @@ async function loadConfigurationFromFile(path: string): Promise<AuthenticationCo
         if (!config.provider) missingFields.push("provider");
         if (!config.issuer) missingFields.push("issuer");
         if (!config.audience) missingFields.push("audience");
-        if (!config.key_id) missingFields.push("key_id");
-        if (!config.key) missingFields.push("key");
 
         if (missingFields.length > 0) {
             throw new Error(`Invalid authentication configuration in ${path}: Missing required fields: ${missingFields.join(", ")}`);
+        }
+
+        const hasJwksUri = !!config.jwks_uri;
+        const hasStaticKey = !!config.key || !!config.key_id;
+
+        // A provider declares either a JWKS endpoint or a static key, not both.
+        if (hasJwksUri && hasStaticKey) {
+            throw new Error(`Invalid authentication configuration in ${path}: jwks_uri is mutually exclusive with key and key_id.`);
+        }
+
+        if (hasJwksUri) {
+            if (typeof config.jwks_uri !== "string" || !/^https?:\/\//.test(config.jwks_uri)) {
+                throw new Error(`Invalid authentication configuration in ${path}: jwks_uri must be an http(s) URL.`);
+            }
+
+            return {
+                provider: config.provider,
+                issuer: config.issuer,
+                audience: config.audience,
+                jwksUri: config.jwks_uri,
+                jwksClient: new jwksRsa.JwksClient({
+                    jwksUri: config.jwks_uri,
+                    cache: true,
+                    cacheMaxEntries: 5,
+                    cacheMaxAge: 600000,
+                    rateLimit: true,
+                    jwksRequestsPerMinute: 10
+                })
+            };
+        }
+
+        const missingKeyFields = [];
+        if (!config.key_id) missingKeyFields.push("key_id");
+        if (!config.key) missingKeyFields.push("key");
+
+        if (missingKeyFields.length > 0) {
+            throw new Error(`Invalid authentication configuration in ${path}: Provide either jwks_uri or a static key. Missing required fields: ${missingKeyFields.join(", ")}`);
         }
 
         return {

--- a/authenticate.ts
+++ b/authenticate.ts
@@ -3,7 +3,7 @@ import { NextFunction, Request, Response } from "express";
 import { readdir, readFile } from "fs/promises";
 import * as iconv from "iconv-lite";
 import { Trace } from "jinaga";
-import { Algorithm, decode, GetPublicKeyOrSecret, JwtHeader, JwtPayload, SigningKeyCallback, verify } from "jsonwebtoken";
+import { Algorithm, decode, JwtHeader, JwtPayload, verify } from "jsonwebtoken";
 import jwksRsa = require("jwks-rsa");
 import { join } from "path";
 
@@ -20,8 +20,11 @@ interface AuthenticationConfiguration {
 const RSA_ALGORITHMS: Algorithm[] = ["RS256"];
 const HMAC_ALGORITHMS: Algorithm[] = ["HS256", "HS384", "HS512"];
 
+// A PEM-encoded asymmetric key (or certificate) begins with a structured
+// header line such as "-----BEGIN PUBLIC KEY-----". A loose substring check
+// would misclassify a symmetric secret that merely contains "-----BEGIN".
 function isPemKey(key: string): boolean {
-    return key.includes("-----BEGIN");
+    return /-----BEGIN (?:[A-Z0-9]+ )*(?:PUBLIC KEY|CERTIFICATE)-----/.test(key);
 }
 
 export function authenticate(configs: AuthenticationConfiguration[], allowAnonymous: boolean) {
@@ -38,13 +41,15 @@ export function authenticate(configs: AuthenticationConfiguration[], allowAnonym
                 const match = authorization.match(/^Bearer (.*)$/);
                 if (match) {
                     const token = match[1];
-                    const payload = decode(token);
-                    if (!payload || typeof payload !== "object") {
+                    const decoded = decode(token, { complete: true });
+                    const payload = decoded?.payload;
+                    if (!decoded || !payload || typeof payload !== "object") {
                         res.set('Access-Control-Allow-Origin', '*');
                         res.status(401).send("Invalid token");
                         Trace.warn(`Invalid token: ${payload}`);
                         return;
                     }
+                    const header = decoded.header;
 
                     // Validate the subject.
                     const subject = payload.sub;
@@ -76,9 +81,17 @@ export function authenticate(configs: AuthenticationConfiguration[], allowAnonym
                     let verified: string | JwtPayload | undefined;
                     let provider: string = "";
                     try {
-                        const result = await verifyToken(token, possibleConfigs);
-                        verified = result.payload;
-                        provider = result.provider;
+                        // Resolve the single config (and its key) that matches this
+                        // token's kid, then verify with an algorithm allowlist scoped
+                        // to that key alone — never a union across providers, which
+                        // would reopen the RS256->HS256 confusion an allowlist closes.
+                        const resolution = await resolveVerificationKey(header, possibleConfigs);
+                        if (resolution) {
+                            verified = await verifyToken(token, resolution.key, resolution.algorithms);
+                            provider = resolution.provider;
+                        } else {
+                            Trace.warn(`No signing key for key ID: ${header.kid}`);
+                        }
                     } catch (error) {
                         Trace.warn(`Error during authentication: ${error instanceof Error ? error.message : error}`);
                     }
@@ -115,66 +128,85 @@ export function authenticate(configs: AuthenticationConfiguration[], allowAnonym
     }
 }
 
+interface ResolvedVerificationKey {
+    key: string;
+    algorithms: Algorithm[];
+    provider: string;
+}
+
 // Resolve the signing key for a token by its `kid`, supporting both static keys
 // (matched by `key_id`) and dynamic JWKS endpoints (resolved by `kid`, with
-// caching and cache-miss refetch handled by jwks-rsa). The verification is
-// asynchronous because JWKS resolution may require a network round-trip.
-function verifyToken(
-    token: string,
+// caching and cache-miss refetch handled by jwks-rsa). Resolution is
+// asynchronous because a JWKS lookup may require a network round-trip.
+//
+// Exactly one config (and therefore one key) is selected, so the algorithm
+// allowlist returned alongside it is scoped to that key's type alone — RS256
+// for asymmetric/JWKS keys, the HMAC family for symmetric secrets. This is
+// deliberate: a union of algorithms across providers sharing an issuer/audience
+// would let an attacker present `alg: HS256` against a PEM public key
+// (algorithm-confusion).
+async function resolveVerificationKey(
+    header: JwtHeader,
     possibleConfigs: AuthenticationConfiguration[]
-): Promise<{ payload: string | JwtPayload; provider: string }> {
-    return new Promise((resolve, reject) => {
-        let provider: string = "";
+): Promise<ResolvedVerificationKey | undefined> {
+    // A `kid` is required to select a key in both modes; fail fast without one.
+    const kid = header.kid;
+    if (!kid) {
+        return undefined;
+    }
 
-        const getKey: GetPublicKeyOrSecret = (header: JwtHeader, callback: SigningKeyCallback) => {
-            // Prefer a static key whose key_id matches the token's kid.
-            const staticConfig = possibleConfigs.find(config => config.key !== undefined && config.keyId === header.kid);
-            if (staticConfig) {
-                provider = staticConfig.provider;
-                callback(null, staticConfig.key);
-                return;
-            }
-
-            // Fall back to a JWKS endpoint, resolving the key by kid.
-            const jwksConfig = possibleConfigs.find(config => config.jwksClient !== undefined);
-            if (jwksConfig && jwksConfig.jwksClient) {
-                provider = jwksConfig.provider;
-                jwksConfig.jwksClient.getSigningKey(header.kid, (error, key) => {
-                    if (error || !key) {
-                        callback(error ?? new Error(`Invalid key ID: ${header.kid}`));
-                        return;
-                    }
-                    callback(null, key.getPublicKey());
-                });
-                return;
-            }
-
-            callback(new Error(`Invalid key ID: ${header.kid}`));
+    // Prefer a static key whose key_id matches the token's kid.
+    const staticConfig = possibleConfigs.find(config => config.key !== undefined && config.keyId === kid);
+    if (staticConfig && staticConfig.key !== undefined) {
+        return {
+            key: staticConfig.key,
+            algorithms: isPemKey(staticConfig.key) ? RSA_ALGORITHMS : HMAC_ALGORITHMS,
+            provider: staticConfig.provider
         };
+    }
 
-        verify(token, getKey, { algorithms: allowedAlgorithms(possibleConfigs) }, (error, payload) => {
-            if (error || !payload) {
-                reject(error ?? new Error("Token verification produced no payload"));
-                return;
+    // Otherwise try each JWKS endpoint, resolving by kid. Trying each (rather
+    // than blindly taking the first) disambiguates when more than one JWKS
+    // provider shares the issuer/audience: the one that actually publishes the
+    // kid wins.
+    for (const config of possibleConfigs) {
+        if (config.jwksClient) {
+            const key = await getSigningKey(config.jwksClient, kid);
+            if (key) {
+                return {
+                    key,
+                    algorithms: RSA_ALGORITHMS,
+                    provider: config.provider
+                };
             }
-            resolve({ payload, provider });
+        }
+    }
+
+    return undefined;
+}
+
+// Promisified jwks-rsa key lookup. Resolves to the PEM public key for the kid,
+// or undefined if the endpoint does not publish it (or the fetch fails).
+function getSigningKey(client: jwksRsa.JwksClient, kid: string): Promise<string | undefined> {
+    return new Promise(resolve => {
+        client.getSigningKey(kid, (error, key) => {
+            resolve(error || !key ? undefined : key.getPublicKey());
         });
     });
 }
 
-// Compute the explicit algorithms allowlist (defense-in-depth against
-// algorithm-confusion attacks such as RS256 -> HS256). Asymmetric keys (PEM or
-// JWKS) permit RS256; static symmetric secrets permit the HMAC family.
-function allowedAlgorithms(possibleConfigs: AuthenticationConfiguration[]): Algorithm[] {
-    const algorithms = new Set<Algorithm>();
-    for (const config of possibleConfigs) {
-        if (config.jwksUri !== undefined || (config.key !== undefined && isPemKey(config.key))) {
-            RSA_ALGORITHMS.forEach(algorithm => algorithms.add(algorithm));
-        } else if (config.key !== undefined) {
-            HMAC_ALGORITHMS.forEach(algorithm => algorithms.add(algorithm));
-        }
-    }
-    return [...algorithms];
+// Verify a token against a single resolved key, constrained to the explicit
+// algorithm allowlist for that key.
+function verifyToken(token: string, key: string, algorithms: Algorithm[]): Promise<string | JwtPayload> {
+    return new Promise((resolve, reject) => {
+        verify(token, key, { algorithms }, (error, payload) => {
+            if (error || !payload) {
+                reject(error ?? new Error("Token verification produced no payload"));
+                return;
+            }
+            resolve(payload);
+        });
+    });
 }
 
 export async function loadAuthenticationConfigurations(path: string): Promise<{ configs: AuthenticationConfiguration[], allowAnonymous: boolean }> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "jinaga": "^6.8.3",
         "jinaga-server": "^3.6.0",
         "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.2.0",
         "pg": "^8.13.1"
       },
       "devDependencies": {
@@ -1991,7 +1992,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
       "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
-      "dev": true,
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
@@ -2014,8 +2014,7 @@
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/mysql": {
       "version": "2.15.26",
@@ -2972,6 +2971,15 @@
         "pg": "^8.13.1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -3016,6 +3024,45 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -3025,10 +3072,21 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -3069,6 +3127,28 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3937,6 +4017,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jinaga": "^6.8.3",
     "jinaga-server": "^3.6.0",
     "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.2.0",
     "pg": "^8.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves #53. A .provider file can now declare a `jwks_uri` instead of a
static `key`/`key_id`, so RS256 signing keys are resolved dynamically by
the token's `kid` against the issuer's JWKS endpoint (with caching and
cache-miss refetch via jwks-rsa). This lets the replicator pair with an
authorization server that rotates keys without operators regenerating the
provider file.

- Make the verification path async (await a Promise-wrapped jsonwebtoken
  verify) so asynchronous JWKS resolution is awaited rather than read as
  undefined.
- Enforce that `jwks_uri` and static `key`/`key_id` are mutually exclusive
  per file, requiring exactly one mode.
- Pass an explicit algorithms allowlist (RS256 for asymmetric/JWKS keys,
  HMAC family for symmetric keys) as defense-in-depth against
  algorithm-confusion attacks.
- Document both provider modes in README and update CLAUDE.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U5ZJ5gsFaSWmZqF5sfXKeR